### PR TITLE
Add an action description

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,6 @@
 ---
 name: Job Context
-description:
+description: Provides additional context for the currently running job
 inputs:
   path:
     description: >-


### PR DESCRIPTION
Turns out this field is required if you want to publish an action to the GitHub marketplace.