### PR TITLE
Fix permissions documentation

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,6 +10,7 @@ jobs:
   test-default-name:
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +31,7 @@ jobs:
     name: Custom Name
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +52,7 @@ jobs:
     name: ""
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -70,6 +73,7 @@ jobs:
     name: null
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -90,6 +94,7 @@ jobs:
     name: false
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -194,6 +199,7 @@ jobs:
     name: ${{ github.job }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     strategy:
       fail-fast: false
@@ -226,6 +232,7 @@ jobs:
     name: Embedded
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - id: dynamic-job

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ jobs:
     # These permissions are needed to:
     # - Use `job-context`: https://github.com/beacon-biosignals/job-context#permissions
     permissions:
+      actions: read
       contents: read
     runs-on: ubuntu-latest
     strategy:
@@ -50,5 +51,6 @@ The following [job permissions](https://docs.github.com/en/actions/using-jobs/as
 
 ```yaml
 permissions:
+  actions: read  # Required for non-public repositories
   contents: read
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     # These permissions are needed to:
     # - Use `job-context`: https://github.com/beacon-biosignals/job-context#permissions
     permissions:
-      context: read
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -46,7 +46,7 @@ The `job-context` action does not support any inputs.
 
 ## Permissions
 
-The follow [job permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) are required to run this action:
+The following [job permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) are required to run this action:
 
 ```yaml
 permissions:

--- a/README.md
+++ b/README.md
@@ -50,5 +50,5 @@ The follow [job permissions](https://docs.github.com/en/actions/using-jobs/assig
 
 ```yaml
 permissions:
-  context: read
+  contents: read
 ```

--- a/action.yaml
+++ b/action.yaml
@@ -87,6 +87,7 @@ runs:
         [[ "$RUNNER_DEBUG" -eq 1 ]] && set -x
         set -euo pipefail
 
+        # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#get-a-workflow-run-attempt
         jobs="$(gh api -X GET "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${run_attempt:?}/jobs")"
         job_ids="$(jq -c --arg name "$job_name" '[.jobs[] | select(.name == $name) | .id]' <<<"${jobs}")"
 


### PR DESCRIPTION
The permission should be [`contents` and not `context`](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) (doesn't exist).