### PR TITLE
Add --paginate to jobs API call

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -88,7 +88,7 @@ runs:
         set -euo pipefail
 
         # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#get-a-workflow-run-attempt
-        jobs="$(gh api -X GET "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${run_attempt:?}/jobs")"
+        jobs="$(gh api --paginate -X GET "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${run_attempt:?}/jobs")"
         job_ids="$(jq -c --arg name "$job_name" '[.jobs[] | select(.name == $name) | .id]' <<<"${jobs}")"
 
         if [[ $(jq length <<<"${job_ids}") -eq 1 ]]; then


### PR DESCRIPTION
Hello! I've been using the [matrix-output](https://github.com/beacon-biosignals/matrix-output) action and it's been super helpful. Recently I ran into an issue where it wouldn't collate output properly if there were too many jobs in the matrix. This is because the API call to `/repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs` only returns the first 30 jobs by default. Adding the `--paginate` option should fix it (I haven't attempted to run the new GitHub Action, but the API call behaves correctly locally.)