### PR TITLE
Fix pagination when workflow jobs exceed 100

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -88,8 +88,9 @@ runs:
         set -euo pipefail
 
         # https://docs.github.com/en/rest/actions/workflow-runs?apiVersion=2022-11-28#get-a-workflow-run-attempt
-        jobs="$(gh api --paginate -X GET "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${run_attempt:?}/jobs")"
-        job_ids="$(jq -c --arg name "$job_name" '[.jobs[] | select(.name == $name) | .id]' <<<"${jobs}")"
+        # Use `jq -s` pipe to merge paginated results together (more than 100 entries).
+        jobs="$(gh api --paginate -X GET "/repos/{owner}/{repo}/actions/runs/${run_id:?}/attempts/${run_attempt:?}/jobs" | jq -s '[.[].jobs[]]')"
+        job_ids="$(jq -c --arg name "$job_name" '[.[] | select(.name == $name) | .id]' <<<"${jobs}")"
 
         if [[ $(jq length <<<"${job_ids}") -eq 1 ]]; then
             echo "id=$(jq 'first' <<<"${job_ids}")" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
When the number of jobs exceeds 100 the pagination results will be broken into separate JSON documents with using `--paginate`. The `--slurp` function doesn't do what I want so 

```
 /home/runner/work/_temp/9b272f9b-3973-4693-b630-b91c3ce57c5d.sh: line 9: [[: 1
0
0: syntax error in expression (error token is "0
0")
ERROR: Unable to determine job ID. The job name "Execute Complex (App One, user/app1, 1.0)" is not unique within the workflow.
Error: Process completed with exit code 1.
```
– https://github.com/beacon-biosignals/matrix-output/actions/runs/22641431677/job/65618229855?pr=21#step:3:792

In this case there are 271 jobs broken into 3 separate paginated requests. Here's a bit of insight into the `jq` query:

```sh
❯ gh api --paginate -X GET "/repos/beacon-biosignals/matrix-output/actions/runs/22641431677/attempts/1/jobs" | jq -s '. | length'
3

❯ gh api --paginate -X GET "/repos/beacon-biosignals/matrix-output/actions/runs/22641431677/attempts/1/jobs" | jq -s '.[].jobs | length'
100
100
71

❯ gh api --paginate -X GET "/repos/beacon-biosignals/matrix-output/actions/runs/22641431677/attempts/1/jobs" | jq -s '[.[].jobs] | length'
3

❯ gh api --paginate -X GET "/repos/beacon-biosignals/matrix-output/actions/runs/22641431677/attempts/1/jobs" | jq -s '[.[].jobs[]] | length'
271
```

Discovered while working on: https://github.com/beacon-biosignals/matrix-output/pull/21